### PR TITLE
Fixed error caused by calling <<-EOS.undent

### DIFF
--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -8,7 +8,7 @@ cask 'blank-screensaver' do
 
   screen_saver "macos-blank-screensaver-#{version}/Blank.qtz"
 
-  caveats do; <<-EOF.undent
+  caveats do; <<~EOF
     NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
     `open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`
     EOF


### PR DESCRIPTION
Installation fails with "Error: Calling <<-EOS.undent is disabled! Use <<~EOS instead." Fixed as suggested. For more details see: https://github.com/Homebrew/brew/issues/3738