### PR TITLE
use version 2.1.1

### DIFF
--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -7,7 +7,7 @@ cask 'blank-screensaver' do
 
   homepage 'https://github.com/theseal/macos-blank-screensaver'
 
-  if MacOS.version == :mojave
+  if MacOS.version == :mojave || MacOS.version == :big_sur
     screen_saver "macos-blank-screensaver-#{version}/Blank.saver"
   else
     screen_saver "macos-blank-screensaver-#{version}/Blank.qtz"

--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -4,7 +4,7 @@ cask 'blank-screensaver' do
 
   url "https://github.com/theseal/macos-blank-screensaver/archive/#{version}.tar.gz"
   name 'Blank'
-
+  desc 'A blank (black) screensaver for MacOS/OS X.'
   homepage 'https://github.com/theseal/macos-blank-screensaver'
 
   if MacOS.version == :mojave || MacOS.version == :big_sur
@@ -13,14 +13,14 @@ cask 'blank-screensaver' do
     screen_saver "macos-blank-screensaver-#{version}/Blank.qtz"
   end
 
+  preflight do
+    File.delete('~/Library/Screen Savers/Blank.qtz') if File.exist?('~/Library/Screen Savers/Blank.qtz')
+    FileUtils.remove_dir('~/Library/Screen Savers/Blank.saver') if File.directory?('~/Library/Screen Savers/Blank.saver')
+  end
+
   caveats <<~EOS
     NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
     `open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`
-
-    If you upgraded from an earlier version of Blank you might need to remove
-    the older version by hand…
-    `rm -r ~/Library/Screen\\ Savers/Blank.*`
-    …and then reinstall the Cask.
   EOS
 
 end

--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -1,6 +1,6 @@
 cask 'blank-screensaver' do
-  version '2.1.0'
-  sha256 '068bafd2707cc9de3cdeedfc8f0d0637b2dbd86c0cb5acb1ff0fec595dd8211d'
+  version '2.1.1'
+  sha256 'fa35c8bd75f09a01abc27cf723bf56b3844ace6b5f911592e75bd9040861edff'
 
   url "https://github.com/theseal/macos-blank-screensaver/archive/#{version}.tar.gz"
   name 'Blank'

--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -18,9 +18,15 @@ cask 'blank-screensaver' do
     FileUtils.remove_dir('~/Library/Screen Savers/Blank.saver') if File.directory?('~/Library/Screen Savers/Blank.saver')
   end
 
+  postflight do
+    if MacOS.version == :big_sur
+      system_command "xattr",
+        args: ["-d", "com.apple.quarantine", "#{ENV["HOME"]}/Library/Screen Savers/Blank.saver"]
+    end
+  end
+
   caveats <<~EOS
     NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
     `open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`
   EOS
-
 end


### PR DESCRIPTION
This uses version 2.1.1 and uses a `preflight` block to clean up old versions if they exist.

``` ~ $ ll ~/Library/Screen\ Savers/

 ~ $ brew tap theseal/blank-screensaver

 ~ $ brew install blank-screensaver
==> Caveats
NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
`open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`

If you upgraded from an earlier version of Blank you might need to remove
the older version by hand…
`rm -r ~/Library/Screen\ Savers/Blank.*`
…and then reinstall the Cask.

==> Downloading https://github.com/theseal/macos-blank-screensaver/archive/2.1.0.tar.gz
==> Downloading from https://codeload.github.com/theseal/macos-blank-screensaver/tar.gz/2.1.0
######################################################################## 100.0%
==> Installing Cask blank-screensaver
==> Moving Screen Saver 'Blank.qtz' to '/Users/mike/Library/Screen Savers/Blank.qtz'.
🍺  blank-screensaver was successfully installed!

 ~ $ ll ~/Library/Screen\ Savers/
.rw-r--r-- mike staff 1.1 KB Sun Feb  2 09:33:38 2020 Blank.qtz
 ~ $ brew untap theseal/blank-screensaver
Untapping theseal/blank-screensaver...
Untapped 1 cask (28 files, 34.5KB).

 ~ $ brew tap mikegoodspeed/blank-screensaver
==> Tapping mikegoodspeed/blank-screensaver
Cloning into '/usr/local/Homebrew/Library/Taps/mikegoodspeed/homebrew-blank-screensaver'...
remote: Enumerating objects: 28, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (15/15), done.
remote: Total 52 (delta 6), reused 28 (delta 6), pack-reused 24
Receiving objects: 100% (52/52), 7.10 KiB | 484.00 KiB/s, done.
Resolving deltas: 100% (9/9), done.
Tapped 1 cask (27 files, 35KB).

 ~ $ brew upgrade blank-screensaver
==> Upgrading 1 outdated package:
mikegoodspeed/blank-screensaver/blank-screensaver 2.1.0 -> 2.1.1
==> Upgrading blank-screensaver
==> Caveats
NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
`open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`

==> Downloading https://github.com/theseal/macos-blank-screensaver/archive/2.1.1.tar.gz
Already downloaded: /Users/mike/Library/Caches/Homebrew/downloads/653bc2d374273bb01aedf93aeb64c8d75e0f9cd49e18a4340328473b6036482f--macos-blank-screensaver-2.1.1.tar.gz
==> Backing Screen Saver 'Blank.qtz' up to '/usr/local/Caskroom/blank-screensaver/2.1.0/macos-blank-screensaver-2.1.0/Blank.qtz'.
==> Removing Screen Saver '/Users/mike/Library/Screen Savers/Blank.qtz'.
==> Moving Screen Saver 'Blank.saver' to '/Users/mike/Library/Screen Savers/Blank.saver'.
==> Purging files for version 2.1.0 of Cask blank-screensaver
🍺  blank-screensaver was successfully upgraded!

 ~ $ ll ~/Library/Screen\ Savers/
drwxr-xr-x mike staff 96 B Wed Nov 18 13:27:31 2020 Blank.saver

 ~ $ brew reinstall blank-screensaver
==> Caveats
NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
`open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`

==> Downloading https://github.com/theseal/macos-blank-screensaver/archive/2.1.1.tar.gz
Already downloaded: /Users/mike/Library/Caches/Homebrew/downloads/653bc2d374273bb01aedf93aeb64c8d75e0f9cd49e18a4340328473b6036482f--macos-blank-screensaver-2.1.1.tar.gz
==> ing Cask blank-screensaver
==> Backing Screen Saver 'Blank.saver' up to '/usr/local/Caskroom/blank-screensaver/2.1.1/macos-blank-screensaver-2.1.1/Blank.saver'.
==> Removing Screen Saver '/Users/mike/Library/Screen Savers/Blank.saver'.
==> Purging files for version 2.1.1 of Cask blank-screensaver
==> Installing Cask blank-screensaver
==> Moving Screen Saver 'Blank.saver' to '/Users/mike/Library/Screen Savers/Blank.saver'.
🍺  blank-screensaver was successfully installed!

 ~ $ ll ~/Library/Screen\ Savers/
drwxr-xr-x mike staff 96 B Wed Nov 18 13:27:31 2020 Blank.saver
```