### PR TITLE
add version 2.1.1

### DIFF
--- a/Casks/blank-screensaver.rb
+++ b/Casks/blank-screensaver.rb
@@ -1,26 +1,32 @@
-cask 'blank-screensaver' do
-  version '2.1.0'
-  sha256 '068bafd2707cc9de3cdeedfc8f0d0637b2dbd86c0cb5acb1ff0fec595dd8211d'
+cask "blank-screensaver" do
+  version "2.1.1"
+  sha256 "fa35c8bd75f09a01abc27cf723bf56b3844ace6b5f911592e75bd9040861edff"
 
   url "https://github.com/theseal/macos-blank-screensaver/archive/#{version}.tar.gz"
-  name 'Blank'
+  name "Blank"
+  desc "Blank (black) screensaver"
+  homepage "https://github.com/theseal/macos-blank-screensaver"
 
-  homepage 'https://github.com/theseal/macos-blank-screensaver'
-
-  if MacOS.version == :mojave
+  if MacOS.version == :mojave || MacOS.version >= :big_sur
     screen_saver "macos-blank-screensaver-#{version}/Blank.saver"
   else
     screen_saver "macos-blank-screensaver-#{version}/Blank.qtz"
   end
 
+  preflight do
+    system_command "rm", args: ["-rf", "#{config.screen_saverdir}/Blank.qtz"]
+    system_command "rm", args: ["-rf", "#{config.screen_saverdir}/Blank.saver"]
+  end
+
+  postflight do
+    if MacOS.version >= :big_sur
+      system_command "xattr",
+                     args: ["-d", "com.apple.quarantine", "#{config.screen_saverdir}/Blank.saver"]
+    end
+  end
+
   caveats <<~EOS
-    NOTE: Don't forget to enable the screensaver named "Blank" in "Desktop & Screen saver".
+    NOTE: Enable the screensaver named "Blank" in "Desktop & Screen saver".
     `open /System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane`
-
-    If you upgraded from an earlier version of Blank you might need to remove
-    the older version by hand…
-    `rm -r ~/Library/Screen\\ Savers/Blank.*`
-    …and then reinstall the Cask.
   EOS
-
 end


### PR DESCRIPTION
* Removes legacy `Blank.qtz` and `Blank.saver` if found.
* Uses `Blank.saver` for `>= big_sur`
* Removes quarantine from `Blank.saver` for `>= big_sur`